### PR TITLE
add another headlines symbol in textTheme

### DIFF
--- a/flutter_readable/lib/src/extensions/context/text_theme.dart
+++ b/flutter_readable/lib/src/extensions/context/text_theme.dart
@@ -31,6 +31,24 @@ extension QXTextTheme on BuildContext {
   /// shortcut for `Theme.of(context).textTheme.headline6``
   TextStyle? get headline6 => Theme.of(this).textTheme.headline6;
 
+  /// shortcut for `Theme.of(context)..textTheme.headline1`
+  TextStyle? get h1 => Theme.of(this).textTheme.headline1;
+
+  /// shortcut for `Theme.of(context).textTheme.headline2`
+  TextStyle? get h2 => Theme.of(this).textTheme.headline2;
+
+  /// shortcut for `Theme.of(context).textTheme.headline3`
+  TextStyle? get h3 => Theme.of(this).textTheme.headline3;
+
+  /// shortcut for `Theme.of(context).textTheme.headline4`
+  TextStyle? get h4 => Theme.of(this).textTheme.headline4;
+
+  /// shortcut for `Theme.of(context).textTheme.headline5`
+  TextStyle? get h5 => Theme.of(this).textTheme.headline5;
+
+  /// shortcut for `Theme.of(context).textTheme.headline6`
+  TextStyle? get h6 => Theme.of(this).textTheme.headline6;
+
   /// shortcut for `Theme.of(context).textTheme.overline``
   TextStyle? get overline => Theme.of(this).textTheme.overline;
 

--- a/flutter_readable/pubspec.lock
+++ b/flutter_readable/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.14.0-360.0.dev <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/flutter_readable/test/extensions/context_test.dart
+++ b/flutter_readable/test/extensions/context_test.dart
@@ -102,6 +102,31 @@ class TestXPage extends StatelessWidget {
                       Theme.of(ctx).textTheme.headline6,
                     ),
 
+                'h1': (ctx) => identical(
+                      ctx.h1,
+                      Theme.of(ctx).textTheme.headline1,
+                    ),
+                'h2': (ctx) => identical(
+                      ctx.h2,
+                      Theme.of(ctx).textTheme.headline2,
+                    ),
+                'h3': (ctx) => identical(
+                      ctx.h3,
+                      Theme.of(ctx).textTheme.headline3,
+                    ),
+                'h4': (ctx) => identical(
+                      ctx.h4,
+                      Theme.of(ctx).textTheme.headline4,
+                    ),
+                'h5': (ctx) => identical(
+                      ctx.h5,
+                      Theme.of(ctx).textTheme.headline5,
+                    ),
+                'h6': (ctx) => identical(
+                      ctx.h6,
+                      Theme.of(ctx).textTheme.headline6,
+                    ),
+
                 /// * theme
                 'theme': (ctx) => identical(ctx.theme, Theme.of(ctx)),
                 'textTheme': (ctx) =>


### PR DESCRIPTION
add another headlines symbol in textTheme
h1 shortcut for `Theme.of(context).textTheme.headline1`
h2 shortcut for `Theme.of(context).textTheme.headline2`
h3 shortcut for `Theme.of(context).textTheme.headline3`
h4 shortcut for `Theme.of(context).textTheme.headline4`
h5 shortcut for `Theme.of(context).textTheme.headline5`
h6 shortcut for `Theme.of(context).textTheme.headline6`